### PR TITLE
Changes towards to the standard Web Audio API

### DIFF
--- a/javascripts/app/Instrument.js
+++ b/javascripts/app/Instrument.js
@@ -14,7 +14,7 @@ Module("App.Instrument", function (Instrument) {
 
   // Inits the instrument instance.
   Instrument.fn.init = function (instrument) {
-    this.masterVolume = this.context.createGainNode();
+    this.masterVolume = this.context.createGain() || this.context.createGainNode();
     this.masterVolume.gain.value = this.volume;
     this.masterVolume.connect(this.context.destination);
 

--- a/javascripts/app/Player.js
+++ b/javascripts/app/Player.js
@@ -6,8 +6,9 @@ Module("App.Player", function (Player) {
 
   Player.fn.initialize = function () {
     // Holds the universal audio context
-    // TODO: adapter for cross-browser implementation
-    this.context = new (AudioContext || webkitAudioContext);
+    var AudioContext = window.AudioContext || window.webkitAudioContext;
+    this.context = new AudioContext();
+
     this.controls = new App.Controls();
     this.isPlaying = false;
 

--- a/javascripts/app/Player.js
+++ b/javascripts/app/Player.js
@@ -7,7 +7,7 @@ Module("App.Player", function (Player) {
   Player.fn.initialize = function () {
     // Holds the universal audio context
     // TODO: adapter for cross-browser implementation
-    this.context = new webkitAudioContext();
+    this.context = new (AudioContext || webkitAudioContext);
     this.controls = new App.Controls();
     this.isPlaying = false;
 


### PR DESCRIPTION
This pull-request:
- Makes retro-audio-js compatible with Firefox Nightly
- Uses the standard WebAudio API methods
- Was tested on Firefox Nightly 26.0a1 (2013-09-15) on Ubuntu 13.04
- Was tested on Chromiun Version 28.0.1500.71 on Ubuntu 13.04
- Was tested on Google Chrome Version 31.0.1626.0 dev on Ubuntu 13.04
